### PR TITLE
Add keyCode mapping for browsers that don't emit a `event.key` property

### DIFF
--- a/src/lrud-input/code-to-binding-map.ts
+++ b/src/lrud-input/code-to-binding-map.ts
@@ -1,8 +1,10 @@
 // This maps a key code, returned from an event, to a handler name.
+// TODO: add configuration of custom key map
 export default {
   38: 'up',
   40: 'down',
   37: 'left',
   39: 'right',
   13: 'select',
+  461: 'back' // webos remote
 };

--- a/src/lrud-input/code-to-binding-map.ts
+++ b/src/lrud-input/code-to-binding-map.ts
@@ -1,0 +1,8 @@
+// This maps a key code, returned from an event, to a handler name.
+export default {
+  38: 'up',
+  40: 'down',
+  37: 'left',
+  39: 'right',
+  13: 'select',
+};

--- a/src/lrud-input/code-to-binding-map.ts
+++ b/src/lrud-input/code-to-binding-map.ts
@@ -6,5 +6,6 @@ export default {
   37: 'left',
   39: 'right',
   13: 'select',
-  461: 'back' // webos remote
+  461: 'back', // webos remote,
+  10009: 'back' // tizen
 };

--- a/src/lrud-input/code-to-binding-map.ts
+++ b/src/lrud-input/code-to-binding-map.ts
@@ -1,5 +1,4 @@
 // This maps a key code, returned from an event, to a handler name.
-// TODO: add configuration of custom key map
 export default {
   8: 'back',
   38: 'up',

--- a/src/lrud-input/code-to-binding-map.ts
+++ b/src/lrud-input/code-to-binding-map.ts
@@ -1,6 +1,7 @@
 // This maps a key code, returned from an event, to a handler name.
 // TODO: add configuration of custom key map
 export default {
+  8: 'back',
   38: 'up',
   40: 'down',
   37: 'left',

--- a/src/lrud-input/focus-lrud.ts
+++ b/src/lrud-input/focus-lrud.ts
@@ -1,5 +1,5 @@
 import throttle from './throttle';
-import keyToBindingMap from './key-to-binding-map';
+import keyToBindingMap from './code-to-binding-map';
 import { FocusStore } from '../types';
 import bubbleKey from './bubble-key-input';
 
@@ -33,7 +33,7 @@ export default function focusLrud(focusStore: FocusStore) {
   const keydownHandler = throttle(
     function (e: KeyboardEvent) {
       // @ts-ignore
-      const bindingName = keyToBindingMap[e.key];
+      const bindingName = keyToBindingMap[e.keyCode];
       // @ts-ignore
       const binding = lrudMapping[bindingName];
 

--- a/src/lrud-input/focus-lrud.ts
+++ b/src/lrud-input/focus-lrud.ts
@@ -33,11 +33,9 @@ export default function focusLrud(focusStore: FocusStore) {
 
   const keydownHandler = throttle(
     function (e: KeyboardEvent) {
-      const bindingName: string = e.key
+      const bindingName =
         // @ts-ignore
-        ? keyToBindingMap[e.key]
-        // @ts-ignore
-        : keyCodeToBindingMap[e.keyCode];
+        (e.key && keyToBindingMap[e.key]) || keyCodeToBindingMap[e.keyCode];
 
       // @ts-ignore
       const binding = lrudMapping[bindingName];

--- a/src/lrud-input/focus-lrud.ts
+++ b/src/lrud-input/focus-lrud.ts
@@ -1,5 +1,6 @@
 import throttle from './throttle';
-import keyToBindingMap from './code-to-binding-map';
+import keyCodeToBindingMap from './code-to-binding-map';
+import keyToBindingMap from './key-to-binding-map';
 import { FocusStore } from '../types';
 import bubbleKey from './bubble-key-input';
 
@@ -32,8 +33,12 @@ export default function focusLrud(focusStore: FocusStore) {
 
   const keydownHandler = throttle(
     function (e: KeyboardEvent) {
-      // @ts-ignore
-      const bindingName = keyToBindingMap[e.keyCode];
+      const bindingName: string = e.key
+        // @ts-ignore
+        ? keyToBindingMap[e.key]
+        // @ts-ignore
+        : keyCodeToBindingMap[e.keyCode];
+
       // @ts-ignore
       const binding = lrudMapping[bindingName];
 

--- a/src/lrud-input/key-to-binding-map.ts
+++ b/src/lrud-input/key-to-binding-map.ts
@@ -6,4 +6,5 @@ export default {
   ArrowRight: 'right',
   Enter: 'select',
   Escape: 'back',
+  Backspace: 'back',
 };

--- a/src/tests/focus-node-events.test.js
+++ b/src/tests/focus-node-events.test.js
@@ -74,6 +74,73 @@ describe('FocusNode Events', () => {
         })
       );
     });
+
+    it('calls when given a keyCode', () => {
+      const rootOnMove = jest.fn();
+      const nodeBOnMove = jest.fn();
+      let focusStore;
+
+      function TestComponent() {
+        focusStore = useFocusStoreDangerously();
+
+        return (
+          <FocusNode onMove={rootOnMove}>
+            <FocusNode focusId="nodeA" />
+            <FocusNode
+              focusId="nodeB"
+              orientation="vertical"
+              onMove={nodeBOnMove}>
+              <FocusNode focusId="nodeB-A" />
+              <FocusNode focusId="nodeB-B" />
+            </FocusNode>
+          </FocusNode>
+        );
+      }
+
+      render(
+        <FocusRoot>
+          <TestComponent />
+        </FocusRoot>
+      );
+
+      // Verify initial state
+      expect(rootOnMove.mock.calls.length).toBe(0);
+      expect(nodeBOnMove.mock.calls.length).toBe(0);
+      expect(focusStore.getState().focusedNodeId).toEqual('nodeA');
+
+      // Arrow Right
+      fireEvent.keyDown(window, {
+        key: 'r', // intentionally unmapped key
+        keyCode: 39,
+      });
+      expect(rootOnMove.mock.calls.length).toBe(1);
+      expect(nodeBOnMove.mock.calls.length).toBe(0);
+      expect(focusStore.getState().focusedNodeId).toEqual('nodeB-A');
+
+      // Arrow Down
+      fireEvent.keyDown(window, {
+        keyCode: 40,
+      });
+      expect(rootOnMove.mock.calls.length).toBe(1);
+      expect(nodeBOnMove.mock.calls.length).toBe(1);
+      expect(focusStore.getState().focusedNodeId).toEqual('nodeB-B');
+
+      // Arrow Up
+      fireEvent.keyDown(window, {
+        keyCode: 38,
+      });
+      expect(rootOnMove.mock.calls.length).toBe(1);
+      expect(nodeBOnMove.mock.calls.length).toBe(2);
+      expect(focusStore.getState().focusedNodeId).toEqual('nodeB-A');
+
+      // Arrow Left
+      fireEvent.keyDown(window, {
+        keyCode: 37,
+      });
+      expect(rootOnMove.mock.calls.length).toBe(2);
+      expect(nodeBOnMove.mock.calls.length).toBe(2);
+      expect(focusStore.getState().focusedNodeId).toEqual('nodeA');
+    });
   });
 
   describe('onBlur/onFocus', () => {
@@ -336,6 +403,69 @@ describe('FocusNode Events', () => {
       fireEvent.keyDown(window, {
         code: 'Escape',
         key: 'Escape',
+      });
+
+      expect(rootonBack.mock.calls.length).toBe(1);
+      expect(nodeAOnBack.mock.calls.length).toBe(1);
+      expect(nodeBOnBack.mock.calls.length).toBe(0);
+
+      expect(rootonBack).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'back',
+          isArrow: false,
+          node: focusStore.getState().nodes.testRoot,
+        })
+      );
+
+      expect(nodeAOnBack).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'back',
+          isArrow: false,
+          node: focusStore.getState().nodes.nodeA,
+        })
+      );
+    });
+
+    it('calls it when Backspace is pressed', () => {
+      const rootonBack = jest.fn();
+      const nodeAOnBack = jest.fn();
+      const nodeBOnBack = jest.fn();
+      let focusStore;
+
+      function TestComponent() {
+        focusStore = useFocusStoreDangerously();
+
+        return (
+          <FocusNode focusId="testRoot" onBack={rootonBack}>
+            <FocusNode
+              focusId="nodeA"
+              onBack={nodeAOnBack}
+              data-testid="nodeA"
+            />
+            <FocusNode
+              focusId="nodeB"
+              data-testid="nodeB"
+              onBack={nodeBOnBack}
+            />
+          </FocusNode>
+        );
+      }
+
+      render(
+        <FocusRoot>
+          <TestComponent />
+        </FocusRoot>
+      );
+
+      expect(focusStore.getState().focusedNodeId).toEqual('nodeA');
+
+      expect(rootonBack.mock.calls.length).toBe(0);
+      expect(nodeAOnBack.mock.calls.length).toBe(0);
+      expect(nodeBOnBack.mock.calls.length).toBe(0);
+
+      fireEvent.keyDown(window, {
+        code: 'Backspace',
+        key: 'Backspace',
       });
 
       expect(rootonBack.mock.calls.length).toBe(1);


### PR DESCRIPTION
Older browsers don't have a `KeyboardEvent.key` property, and so requires a fallback to the legacy `KeyboardEvent .keyCode`

This pulls in the changes from https://github.com/mgroh/lrud/tree/webos-keycodes but modifies the behaviour slightly to use the `key` property if it exists.

This also maps the `Backspace` key to "back" actions, as used on certain browser environments (e.g. PlayStation 4)